### PR TITLE
Pull build number from environment, default to 0

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -9,7 +9,7 @@ source:
   git_url: https://github.com/fermi-lat/ScienceTools.git
 
 build:
-  number: 0
+  number: {{ environ.get('BUILD_NUMBER', 0)}}
   skip: true  # [win]
   skip: true  # [py3k]
   #- {{ compiler('c') }}
@@ -70,10 +70,10 @@ test:
   imports:
     - UnbinnedAnalysis
     - pyLikelihood
-  
+
   commands:
     # These tests inspect linkages and libraries. They are very slow, so comment them out
     # for a quicker turnaround when testing
     #- conda inspect linkages -p $PREFIX {{ name }}  # [not win]
     #- conda inspect objects -p $PREFIX {{ name }}  # [osx]
-    
+


### PR DESCRIPTION
Simple change to enable Jenkins builds to increment the build number automatically without affecting the version number.