### PR TITLE
Fix #3

### DIFF
--- a/activate.csh
+++ b/activate.csh
@@ -70,9 +70,9 @@ endif
 cat <<- EOF | root -b -l
 TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "hey");
 
-# The formatting with the { at the end of the line is NECESSARY
-# for this to work properly (as this is input for the stdin of
-# root)
+// The formatting with the { at the end of the line is NECESSARY
+// for this to work properly (as this is input for the stdin of
+// root)
 
 if(!old_value.Contains("lib/${condaname}")) { 
     TString new_value = old_value + TString(":${CONDA_PREFIX}/lib/${condaname}/");

--- a/activate.csh
+++ b/activate.csh
@@ -68,7 +68,9 @@ endif
 # because the dynamic loader of ROOT does not honor RPATH
 
 cat <<- EOF | root -b -l
-TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "hey");
+// I am using "default" as default value because I was having problems
+// using the empty string.
+TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "default");
 
 // The formatting with the { at the end of the line is NECESSARY
 // for this to work properly (as this is input for the stdin of

--- a/activate.sh
+++ b/activate.sh
@@ -96,9 +96,9 @@ cat <<- EOF | root -b -l
 
 TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "hey");
 
-// The formatting with the { at the end of the line is NECESSARY
-// for this to work properly (as this is input for the stdin of
-// root)
+# The formatting with the { at the end of the line is NECESSARY
+# for this to work properly (as this is input for the stdin of
+# root)
 if(!old_value.Contains("lib/${condaname}")) { 
     TString new_value = old_value + TString(":${CONDA_PREFIX}/lib/${condaname}/");
 

--- a/activate.sh
+++ b/activate.sh
@@ -96,9 +96,9 @@ cat <<- EOF | root -b -l
 
 TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "hey");
 
-# The formatting with the { at the end of the line is NECESSARY
-# for this to work properly (as this is input for the stdin of
-# root)
+// The formatting with the { at the end of the line is NECESSARY
+// for this to work properly (as this is input for the stdin of
+// root)
 if(!old_value.Contains("lib/${condaname}")) { 
     TString new_value = old_value + TString(":${CONDA_PREFIX}/lib/${condaname}/");
 

--- a/activate.sh
+++ b/activate.sh
@@ -93,7 +93,8 @@ fi
 # because the dynamic loader of ROOT does not honor RPATH
 
 cat <<- EOF | root -b -l
-
+// I am using "default" as default value because I was having problems
+// using the empty string.
 TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "default");
 
 // The formatting with the { at the end of the line is NECESSARY

--- a/activate.sh
+++ b/activate.sh
@@ -2,36 +2,22 @@
 
 export condaname="fermitools"
 
-function string_replace {
-    echo "${1/\*/$2}"
-}
 
 # This instructs the Fermi ST where to find their data
 
 export INST_DIR=$CONDA_PREFIX/share/${condaname}
-export FERMI_DIR=$INST_DIR
 export BASE_DIR=$INST_DIR
 export EXTFILESSYS=$CONDA_PREFIX/share/${condaname}/refdata/fermi
 export GENERICSOURCESDATAPATH=$CONDA_PREFIX/share/${condaname}/data/genericSources
 export TIMING_DIR=$CONDA_PREFIX/share/${condaname}/refdata/fermi/jplephem
 #export PFILES=$CONDA_PREFIX/share/${condaname}/syspfiles
 
-# Keep a copy of the current path so we can restore
+# Keep a copy of the current path so we can restore 
 # upon deactivation
 export FERMI_OLD_PATH=$PATH
 
-# The new path to check or add
-NEW_FERMI_PATH=$CONDA_PREFIX/bin/${condaname}
-
-# Check that the new path is not already a member of the $PATH
-if [[ ${PATH} != *"${NEW_FERMI_PATH}"* ]]; then
-
-    # Add the new fermi path to the $PATH
-    export PATH=${NEW_FERMI_PATH}:${PATH}
-
-fi
-
 # Add path for the ST binaries
+export PATH=$CONDA_PREFIX/bin/${condaname}:${PATH}
 
 # Setup PFILES
 
@@ -39,30 +25,30 @@ fi
 # PFILES is not set)
 export FERMI_OLD_PFILES=$PFILES
 
-if [ -z ${PFILES+x} ]; then
-
+if [ -z ${PFILES+x} ]; then 
+    
     # PFILES is unset, set it appropriately
     mkdir -p $HOME/pfiles
-
-    export PFILES=".:${HOME}/pfiles;${INST_DIR}/syspfiles"
-
-else
-
-    if [[ ${PFILES} == *[';']* ]]; then
-
+    
+    export PFILES=".:${HOME}/pfiles:${INST_DIR}/syspfiles"
+    
+else 
+    
+    if [[ $1 == *[';']* ]]; then
+        
         # current value already contains a ';', which
         # separates read-write pfiles path to read-only
         # pfiles path. Just add the ST one
-
-        export PFILES="${PFILES}:${INST_DIR}/syspfiles"
-
+        
+        export PFILES="${PFILES};${INST_DIR}/syspfiles"
+    
     else
-
+        
         # Current value doesn't have any read-only
         # pfiles path. Add the ST one.
-
+        
         export PFILES="${PFILES};${INST_DIR}/syspfiles"
-
+    
     fi
 
 
@@ -71,21 +57,40 @@ fi
 # Make sure there is no ROOTSYS (which would confuse ROOT)
 unset ROOTSYS
 
-# We need to add the path to the ST library dir to the
-# path that ROOT will search for libraries, because ROOT
-# does not honor RPATH
+# Check whether the .rootrc file exists in the user home,
+# if not create it
+if [ -f "${HOME}/.rootrc" ]; then
+        
+    # Make it read/write
+    chmod u+rw ${HOME}/.rootrc
 
-cat << EOF | root -b -l
+else
+        
+    # File does not exist. Copy the system.rootrc file
+    cp ${CONDA_PREFIX}/etc/root/system.rootrc ${HOME}/.rootrc
+    
+    # Make it read/write
+    chmod u+rw ${HOME}/.rootrc
+
+fi
+
+# We need to make sure that the path to the ST library dir is
+# contained in the paths that ROOT will search for libraries, 
+# because the dynamic loader of ROOT does not honor RPATH
+
+cat <<- EOF | root -b -l
 
 TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "hey");
 
-if(!old_value.Contains("lib/${condaname}"))
-{
+// The formatting with the { at the end of the line is NECESSARY
+// for this to work properly (as this is input for the stdin of
+// root)
+if(!old_value.Contains("lib/${condaname}")) { 
     TString new_value = old_value + TString(":${CONDA_PREFIX}/lib/${condaname}/");
 
     gEnv->SetValue("Unix.*.Root.DynamicPath", new_value);
 
-    gEnv->SaveLevel(kEnvGlobal);
+    gEnv->SaveLevel(kEnvUser);
 }
 
 exit();
@@ -102,24 +107,25 @@ alias ObsSim="python $sitepackagesdir/${condaname}/ObsSim.py"
 
 # Issue warnings if PYTHONPATH and/or LD_LIBRARY_PATH are set
 
-if [ -z ${LD_LIBRARY_PATH+x} ]; then
-
+if [ -z ${LD_LIBRARY_PATH+x} ]; then 
+    
     :
 
 else
-
+    
     # Issue warning
     echo "You have LD_LIBRARY_PATH set. This might interfere with the correct functioning of conda and the Fermi ST"
 
 fi
 
-if [ -z ${PYTHONPATH+x} ]; then
-
+if [ -z ${PYTHONPATH+x} ]; then 
+    
     :
 
 else
-
+    
     # Issue warning
     echo "You have PYTHONPATH set. This might interfere with the correct functioning of conda and the Fermi ST"
 
 fi
+

--- a/activate.sh
+++ b/activate.sh
@@ -94,7 +94,7 @@ fi
 
 cat <<- EOF | root -b -l
 
-TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "hey");
+TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "default");
 
 // The formatting with the { at the end of the line is NECESSARY
 // for this to work properly (as this is input for the stdin of

--- a/activate.sh
+++ b/activate.sh
@@ -2,22 +2,36 @@
 
 export condaname="fermitools"
 
+function string_replace {
+    echo "${1/\*/$2}"
+}
 
 # This instructs the Fermi ST where to find their data
 
 export INST_DIR=$CONDA_PREFIX/share/${condaname}
+export FERMI_DIR=$INST_DIR
 export BASE_DIR=$INST_DIR
 export EXTFILESSYS=$CONDA_PREFIX/share/${condaname}/refdata/fermi
 export GENERICSOURCESDATAPATH=$CONDA_PREFIX/share/${condaname}/data/genericSources
 export TIMING_DIR=$CONDA_PREFIX/share/${condaname}/refdata/fermi/jplephem
 #export PFILES=$CONDA_PREFIX/share/${condaname}/syspfiles
 
-# Keep a copy of the current path so we can restore 
+# Keep a copy of the current path so we can restore
 # upon deactivation
 export FERMI_OLD_PATH=$PATH
 
+# The new path to check or add
+NEW_FERMI_PATH=$CONDA_PREFIX/bin/${condaname}
+
+# Check that the new path is not already a member of the $PATH
+if [[ ${PATH} != *"${NEW_FERMI_PATH}"* ]]; then
+
+    # Add the new fermi path to the $PATH
+    export PATH=${NEW_FERMI_PATH}:${PATH}
+
+fi
+
 # Add path for the ST binaries
-export PATH=$CONDA_PREFIX/bin/${condaname}:${PATH}
 
 # Setup PFILES
 
@@ -25,30 +39,30 @@ export PATH=$CONDA_PREFIX/bin/${condaname}:${PATH}
 # PFILES is not set)
 export FERMI_OLD_PFILES=$PFILES
 
-if [ -z ${PFILES+x} ]; then 
-    
+if [ -z ${PFILES+x} ]; then
+
     # PFILES is unset, set it appropriately
     mkdir -p $HOME/pfiles
-    
-    export PFILES=".:${HOME}/pfiles:${INST_DIR}/syspfiles"
-    
-else 
-    
-    if [[ $1 == *[';']* ]]; then
-        
+
+    export PFILES=".:${HOME}/pfiles;${INST_DIR}/syspfiles"
+
+else
+
+    if [[ ${PFILES} == *[';']* ]]; then
+
         # current value already contains a ';', which
         # separates read-write pfiles path to read-only
         # pfiles path. Just add the ST one
-        
-        export PFILES="${PFILES};${INST_DIR}/syspfiles"
-    
+
+        export PFILES="${PFILES}:${INST_DIR}/syspfiles"
+
     else
-        
+
         # Current value doesn't have any read-only
         # pfiles path. Add the ST one.
-        
+
         export PFILES="${PFILES};${INST_DIR}/syspfiles"
-    
+
     fi
 
 
@@ -97,7 +111,6 @@ exit();
 
 EOF
 
-
 # Add aliases for python executables
 sitepackagesdir=$(python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
@@ -107,25 +120,24 @@ alias ObsSim="python $sitepackagesdir/${condaname}/ObsSim.py"
 
 # Issue warnings if PYTHONPATH and/or LD_LIBRARY_PATH are set
 
-if [ -z ${LD_LIBRARY_PATH+x} ]; then 
-    
+if [ -z ${LD_LIBRARY_PATH+x} ]; then
+
     :
 
 else
-    
+
     # Issue warning
     echo "You have LD_LIBRARY_PATH set. This might interfere with the correct functioning of conda and the Fermi ST"
 
 fi
 
-if [ -z ${PYTHONPATH+x} ]; then 
-    
+if [ -z ${PYTHONPATH+x} ]; then
+
     :
 
 else
-    
+
     # Issue warning
     echo "You have PYTHONPATH set. This might interfere with the correct functioning of conda and the Fermi ST"
 
 fi
-

--- a/deactivate.csh
+++ b/deactivate.csh
@@ -24,19 +24,3 @@ endif
 unalias gtburst
 unalias ModelEditor
 unalias ObsSim
-
-# We need to remove the path to the ST library dir from the 
-# path that ROOT will search for libraries
-
-cat << EOF | root -b -l
-TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "default");
-TString new_value;
-TObjArray *tx=old_value.Tokenize(":");
-for (Int_t i = 0; i < tx->GetEntries(); i++) {
-     TString this_string(((TObjString *)(tx->At(i)))->String());
-     if (!this_string.Contains("lib/${condaname}")) new_value += this_string += ":";
-     }
-gEnv->SetValue("Unix.*.Root.DynamicPath", new_value);
-gEnv->SaveLevel(kEnvGlobal);
-exit();
-EOF

--- a/deactivate.sh
+++ b/deactivate.sh
@@ -34,30 +34,3 @@ fi
 unalias gtburst
 unalias ModelEditor
 unalias ObsSim
-
-# We need to remove the path to the ST library dir from the 
-# path that ROOT will search for libraries
-
-cat << EOF | root -b -l
-
-TString old_value=gEnv->GetValue("Unix.*.Root.DynamicPath", "default");
-
-TString new_value;
-
-TObjArray *tx=old_value.Tokenize(":");
-
-for (Int_t i = 0; i < tx->GetEntries(); i++) {
-
-    TString this_string(((TObjString *)(tx->At(i)))->String());
-    
-    if (!this_string.Contains("lib/${condaname}")) new_value += this_string += ":";
-
-}
-
-gEnv->SetValue("Unix.*.Root.DynamicPath", new_value);
-
-gEnv->SaveLevel(kEnvGlobal);
-
-exit();
-
-EOF


### PR DESCRIPTION
* using the `.rootrc` file instead of the `${CONDA_PREFIX}/etc/root/system.rootrc` file to store the settings
* make sure that the paths in which the ROOT dynamic linker look for libraries always contain the `fermitools` library directory
* fix #3 : now the check is working and the new path is added only if needed
* we do not attempt anymore to remove the ST path from the ROOT dynamic linker paths on deactivation. Deactivation is seldom run by the user, so we shouldn't rely on it. 